### PR TITLE
${root.project}/settings.gradle: renamed the root module to the new name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "CrossPlatformModule"
+rootProject.name = "Cross-platform-template"
 include ':android'
 include ':desktop'
 include ':game'


### PR DESCRIPTION
This PR renames the root module to `Cross-platform-template`.